### PR TITLE
Updated markdown and asset fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
+# Health Cards Tests
+
 ## Using the hosted demo components
 
-### Mobile Wallet demo at https://c19.cards
+### Mobile Wallet demo at <https://c19.cards>
 
-* Click "Connect to Lab and get tested" to retrieve a VC
-* Review details (URLs, DIDs, keys, etc) in Dev Tools
-* Menu > "Scan QR Code" to share your VC with a verifier (e.g., the Verifier demo below)
+- Click "Connect to Lab and get tested" to retrieve a VC
+- Review details (URLs, DIDs, keys, etc) in Dev Tools
+- Menu > "Scan QR Code" to share your VC with a verifier (e.g., the Verifier demo below)
 
-### Verifier demo at https://c19.cards/venue
+### Verifier demo at <https://c19.cards/venue>
 
-* OpenID Request QR code is displayed automatically
-* Review details (URLs, DIDs, keys, etc) in Dev Tools
-* Scan the barcode from your Mobile Wallet to share your VC (e.g., the Mobile Wallet demo above)
+- OpenID Request QR code is displayed automatically
+- Review details (URLs, DIDs, keys, etc) in Dev Tools
+- Scan the barcode from your Mobile Wallet to share your VC (e.g., the Mobile Wallet demo above)
 
-###  Lab demo at https://c19.cards/api/fhir
+### Lab demo at <https://c19.cards/api/fhir>
 
-* Connect your own Mobile Wallet to this demo lab interface
-* Supports SMART on FHIR discovery protocol (https://c19.cards/api/fhir/.well-known/smart-configuration)
-* No UI provided -- just an automatic "sign-in" workflow that redirects back to your Mobile Wallet
-
-
+- Connect your own Mobile Wallet to this demo lab interface
+- Supports SMART on FHIR discovery protocol (<https://c19.cards/api/fhir/.well-known/smart-configuration>)
+- No UI provided -- just an automatic "sign-in" workflow that redirects back to your Mobile Wallet
 
 ## Run locally in dev, with node and parcel watchers
 
-This demo should work wiht Node.js 15 (current LTS) as well as Node.js 13. See `Dockerfile` for details if you want to build/develop locally using docker; otherwise, you can get started with:
+This demo should work with Node.js 15 (current LTS) as well as Node.js 13. See `Dockerfile` for details if you want to build/develop locally using docker; otherwise, you can get started with:
 
     git clone https://github.com/smart-on-fhir/health-cards-tests
     cd health-cards-tests
@@ -35,28 +35,32 @@ This demo should work wiht Node.js 15 (current LTS) as well as Node.js 13. See `
     export SERVER_BASE=http://localhost:8080/api
     npm run dev    # Terminal 2
 
-
 ## Build and run locally (no watchers)
+
     npm run build-ui
     npm run build
 
     export SERVER_BASE=http://localhost:8080/api
     npm run dev
-    
+
 ## Run locally in Docker
+
     docker build -t health-wallet-demo .
     docker run --rm -it --env SERVER_BASE=http://localhost:8080/api -p 8080:8080 health-wallet-demo
 
 ## Run dev-only containers with watchers in Docker-Compose
-    export USER=$(id -u) 
+
+    export USER=$(id -u)
     docker-compose --env-file ./compose.env up
-   
+
 You can use the docker-compose.yaml file to spin up two dev containers with watchers, one for the UI and one for the server.
 
-### Note the following:
-1. Both containers have their `src` directories bind-mounted to the local directory's `src` folder. Any changes made in the `dev` container (or the host) will propagate to both containers + host and be registered by the watchers. This is helpful since you can, for instance, launch programs inside the `dev` container and utilize dev dependencies without needing to ever install them locally.
-2. Both containers have their `dist` folders mounted to a named volume. This means the parcel watcher in the `dev-ui` container can write changes that are accessible by the `dev` container. Note the `dev-ui` container needs `root` priviliges for this. See this [issue](https://github.com/moby/moby/issues/2259) for details. 
-3. The `dev-ui` container has `root` priviliges, but it has been given read-only access to the `src` folder. Any changes to `src` made from within this container will not be seen by the host or `dev` container.  
+### Note the following
 
-## Testing endpoins
+1. Both containers have their `src` directories bind-mounted to the local directory's `src` folder. Any changes made in the `dev` container (or the host) will propagate to both containers + host and be registered by the watchers. This is helpful since you can, for instance, launch programs inside the `dev` container and utilize dev dependencies without needing to ever install them locally.
+2. Both containers have their `dist` folders mounted to a named volume. This means the parcel watcher in the `dev-ui` container can write changes that are accessible by the `dev` container. Note the `dev-ui` container needs `root` privileges for this. See this [issue](https://github.com/moby/moby/issues/2259) for details.
+3. The `dev-ui` container has `root` privileges, but it has been given read-only access to the `src` folder. Any changes to `src` made from within this container will not be seen by the host or `dev` container.
+
+## Testing endpoints
+
 See [testing-endpoints.md](./testing-endpoints.md) for details.

--- a/src/holder-page.tsx
+++ b/src/holder-page.tsx
@@ -14,6 +14,7 @@ import { QRPresentationModal } from './Modals';
 import { parseSiopApprovalProps, SiopApprovalModal, SiopRequestReceiver } from './SiopApproval';
 import './style.css';
 import { verifierWorld } from './verifier';
+import logo from "./img/wallet.svg";
 
 interface IssuerProps {
     issuerStartUrl: string;
@@ -169,7 +170,7 @@ const App: React.FC<AppProps> = (props) => {
         <RS.Navbar expand="" className="navbar-dark bg-info fixed-top">
             <RS.Container>
                 <NavbarBrand style={{ marginRight: "2em" }} href="/">
-                    <img className="d-inline-block" style={{ maxHeight: "1em", maxWidth: "1em", marginRight: "10px" }} src="img/wallet.svg" />
+                    <img className="d-inline-block" style={{ maxHeight: "1em", maxWidth: "1em", marginRight: "10px" }} src={logo} />
                             Health Wallet Demo
                     </NavbarBrand>
                 <NavbarToggler onClick={toggle} />

--- a/src/venue-page.tsx
+++ b/src/venue-page.tsx
@@ -10,6 +10,7 @@ import './style.css';
 import { initializeVerifier, receiveSiopResponse } from './verifier';
 import { prepareSiopRequest, verifierReducer } from './VerifierLogic';
 import { VerifierState } from './VerifierState';
+import logo from "./img/wallet.svg";
 
 export const QrDisplay: React.FC<{ numeric?: number[], url?: string, noLink?: boolean }> = (props) => {
     useEffect(() => {
@@ -81,7 +82,7 @@ const App: React.FC<{
         <RS.Navbar expand="" className="navbar navbar-dark bg-success fixed-top">
             <RS.Container>
                 <NavbarBrand style={{ marginRight: "2em" }} href="/">
-                    <img className="d-inline-block" style={{ maxHeight: "1em", maxWidth: "1em", marginRight: "10px" }} src="img/wallet.svg" />
+                    <img className="d-inline-block" style={{ maxHeight: "1em", maxWidth: "1em", marginRight: "10px" }} src={logo} />
                             Share your COVID Card with <b>Venue</b>
                 </NavbarBrand>
             </RS.Container>


### PR DESCRIPTION
1. Updates to instructions + Markdown linting and fixes the following highlighted. 

![image](https://user-images.githubusercontent.com/980887/114228773-f01a1880-9944-11eb-9961-456992664cc1.png)




2. Fixes local assets references and eliminate the console errors

**Before**
![](https://user-images.githubusercontent.com/980887/114196897-ce5a6a80-991f-11eb-948c-e1f79cd5e773.png)

**After**
![](https://user-images.githubusercontent.com/980887/114196955-ddd9b380-991f-11eb-9950-d13516698e97.png)

@jmandel -- also closed the other PR but do reference the comments, if you haven't seen them. https://github.com/smart-on-fhir/health-cards-tests/pull/50
