### PR TITLE
Fix issue where blocked camera causes error

### DIFF
--- a/demo-portals/public/qrscanner.js
+++ b/demo-portals/public/qrscanner.js
@@ -33,13 +33,17 @@ const QrScanner = function (vidId) {
             promise.resolve = resolve;
             promise.reject = reject;
             // Use facingMode: environment to attempt to get the front camera on phones
-            navigator.mediaDevices.getUserMedia({ video: { width: 600, facingMode: "environment" } }).then(function (stream) {
+            navigator.mediaDevices.getUserMedia({ video: { width: 600, facingMode: "environment" } })
+                .then(function (stream) {
                 video.srcObject = stream;
                 video.setAttribute("playsinline", true); // required to tell iOS safari we don't want fullscreen
                 video.play();
                 vidStream = stream;
 
                 requestAnimationFrame(tick);
+                })
+                .catch(function (error) {
+                    resolve({ error: error.message });
             });
         });
     }

--- a/demo-portals/public/verifier/qr.js
+++ b/demo-portals/public/verifier/qr.js
@@ -82,6 +82,12 @@ const secScanQr = (() => {
             let label = 'Parts : ';
             const scanResult = await qrScanner.scan();
 
+            // if the scanner returns an error
+            if (scanResult?.error) {
+                alert(`Camera Error '${scanResult.error}'`);
+                break;
+            };
+
             // if the scanner was closed by the user
             if (scanResult?.state === 'stopped') break;
 


### PR DESCRIPTION
Trying to scan a qr code when the camera was disabled resulted an endless loop
- Added catch for failed acquisition
- Alert when camera throws error 